### PR TITLE
fix(start.bat): Add validation for virtual environment

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -60,8 +60,27 @@ echo.
 
 REM --- Virtual Environment Setup ---
 set VENV_DIR=venv
+set VENV_PYTHON=%VENV_DIR%\Scripts\python.exe
+set VENV_NEEDS_CREATION=0
 
-if not exist %VENV_DIR%\Scripts\activate.bat (
+REM Check if the virtual environment exists and is valid
+if exist %VENV_PYTHON% (
+    echo Found existing virtual environment. Verifying...
+    %VENV_PYTHON% --version 2>&1 | findstr /C:"Python 3" >nul
+    if errorlevel 1 (
+        echo WARNING: The existing virtual environment in '%VENV_DIR%' seems corrupted or uses a non-Python 3 version.
+        echo Deleting the old environment to recreate it.
+        rmdir /s /q %VENV_DIR% >nul 2>&1
+        set VENV_NEEDS_CREATION=1
+    ) else (
+        echo Virtual environment is valid.
+    )
+) else (
+    set VENV_NEEDS_CREATION=1
+)
+
+REM Create the virtual environment if it's marked for creation
+if %VENV_NEEDS_CREATION% equ 1 (
     echo Creating virtual environment in '%VENV_DIR%'...
     %PYTHON_CMD% -m venv %VENV_DIR%
     if errorlevel 1 (


### PR DESCRIPTION
The start.bat script would previously fail if an existing 'venv' directory was corrupted or pointed to an uninstalled Python version. This was because it only checked for the existence of the activate script, not the validity of the virtual environment itself.

This change adds a verification step that checks if 'venv/Scripts/python.exe' is a valid Python 3 interpreter. If the check fails, the script will automatically delete the corrupted 'venv' directory and create a new one, preventing the error and making the startup process more resilient.